### PR TITLE
Adding support for SYCL

### DIFF
--- a/include/bns_nurates.hpp
+++ b/include/bns_nurates.hpp
@@ -54,7 +54,7 @@ typedef REAL_TYPE BS_REAL;
 #define dim_pair_t 100
 
 // Define maximum number of quadrature points
-#define n_max 40
+#define BS_N_MAX 40
 
 /* ==================================================================================
  * Integration structures
@@ -110,9 +110,9 @@ struct MyQuadrature
     BS_REAL z1; // lower limit of z, set to -42 if unused
     BS_REAL z2; // upper limit of z, set to -42 if unused
     BS_REAL
-    points[n_max];    // points for the quadrature scheme (store points in the
+    points[BS_N_MAX];    // points for the quadrature scheme (store points in the
                       // points direction, then y and z in one flat array)
-    BS_REAL w[n_max]; // weights for the quadrature scheme (store points in the
+    BS_REAL w[BS_N_MAX]; // weights for the quadrature scheme (store points in the
                       // points direction, then y and z in one flat array)
 };
 typedef struct MyQuadrature MyQuadrature;
@@ -474,22 +474,22 @@ typedef struct M1Matrix M1Matrix;
 
 struct M1MatrixKokkos2D
 {
-    BS_REAL m1_mat_em[total_num_species][n_max][n_max];
-    BS_REAL m1_mat_ab[total_num_species][n_max][n_max];
+    BS_REAL m1_mat_em[total_num_species][BS_N_MAX][BS_N_MAX];
+    BS_REAL m1_mat_ab[total_num_species][BS_N_MAX][BS_N_MAX];
 };
 typedef struct M1MatrixKokkos2D M1MatrixKokkos2D;
 
 struct M1MatrixKokkos2DFlatten
 {
-    BS_REAL m1_mat_em[total_num_species][n_max * n_max];
-    BS_REAL m1_mat_ab[total_num_species][n_max * n_max];
+    BS_REAL m1_mat_em[total_num_species][BS_N_MAX * BS_N_MAX];
+    BS_REAL m1_mat_ab[total_num_species][BS_N_MAX * BS_N_MAX];
 };
 typedef struct M1MatrixKokkos2DFlatten M1MatrixKokkos2DFlatten;
 
 
 struct M1MatrixKokkos1D
 {
-    BS_REAL m1_mat[12][n_max];
+    BS_REAL m1_mat[12][BS_N_MAX];
 };
 typedef struct M1MatrixKokkos1D M1MatrixKokkos1D;
 

--- a/include/bns_nurates.hpp
+++ b/include/bns_nurates.hpp
@@ -536,7 +536,7 @@ typedef struct MyFunctionSpecial MyFunctionSpecial;
 inline void BS_do_assert(const char* snippet, const char* file, int line,
                          const char* message, ...)
 {
-    printf("\n\n---- Assert failed ----\n"
+    Kokkos::printf("\n\n---- Assert failed ----\n"
            "EXPRESSION: %s\n"
            "FILE: %s\n"
            "LINE: %d\n\n",
@@ -550,7 +550,7 @@ inline void BS_do_assert(const char* snippet, const char* file, int line,
         vprintf(data, arg);
     }
 
-    printf("\n\n");
+    Kokkos::printf("\n\n");
     fflush(stdout);
 
     abort();

--- a/include/bns_nurates.hpp
+++ b/include/bns_nurates.hpp
@@ -37,8 +37,10 @@ typedef REAL_TYPE BS_REAL;
 #ifndef KOKKOS_INLINE_FUNCTION
 #ifdef KOKKOS_FLAG
 #include <Kokkos_Core.hpp>
+#define BS_PRINTF Kokkos::printf
 #else
 #define KOKKOS_INLINE_FUNCTION inline
+#define BS_PRINTF printf
 #endif
 #endif
 
@@ -536,7 +538,7 @@ typedef struct MyFunctionSpecial MyFunctionSpecial;
 inline void BS_do_assert(const char* snippet, const char* file, int line,
                          const char* message, ...)
 {
-    Kokkos::printf("\n\n---- Assert failed ----\n"
+    BS_PRINTF("\n\n---- Assert failed ----\n"
            "EXPRESSION: %s\n"
            "FILE: %s\n"
            "LINE: %d\n\n",
@@ -550,7 +552,7 @@ inline void BS_do_assert(const char* snippet, const char* file, int line,
         vprintf(data, arg);
     }
 
-    Kokkos::printf("\n\n");
+    BS_PRINTF("\n\n");
     fflush(stdout);
 
     abort();

--- a/include/functions.hpp
+++ b/include/functions.hpp
@@ -29,12 +29,12 @@ constexpr BS_REAL fdi_litconst          = 7.38905609893065023;
 #ifndef _USENRERRORCLASS_
 #define throw(message)                                                         \
     //} //\
-        //printf("ERROR: %s\n     in file %s at line %d\n", message, __FILE__, \
+        //Kokkos::printf("ERROR: %s\n     in file %s at line %d\n", message, __FILE__, \
                __LINE__);
                                                                      \
         //exit(1);
         //BS_REAL dummy_var = -42.;
-        printf("Throw function here");
+        Kokkos::printf("Throw function here");
                                                                       \
     //}
 #else
@@ -50,7 +50,7 @@ struct NRerror
 #define throw(message) throw(NRerror(message, __FILE__, __LINE__));
 void NRcatch(NRerror err)
 {
-    printf("ERROR: %s\n     in file %s at line %d\n", err.message, err.file,
+    Kokkos::printf("ERROR: %s\n     in file %s at line %d\n", err.message, err.file,
            err.line);
     exit(1);
 }
@@ -327,7 +327,7 @@ void SFPsiOutput(const BS_REAL x, SFResult* result)
     {
         // result->val = std::nan;
         // result->err = std::nan;
-        printf("Error in digamma computation\n");
+        Kokkos::printf("Error in digamma computation\n");
         exit(EXIT_FAILURE);
     }
     else if (y >= 2.0)
@@ -343,7 +343,7 @@ void SFPsiOutput(const BS_REAL x, SFResult* result)
             {
                 // result->val = std::nan;
                 // result->err = std::nan;
-                printf("Error in digamma computation\n");
+                Kokkos::printf("Error in digamma computation\n");
                 exit(EXIT_FAILURE);
             }
             else
@@ -4433,7 +4433,7 @@ BS_REAL Gammln(const BS_REAL xx)
     if (xx <= 0)
     {
         // throw("bad arg in gammln");
-        printf("bad arg in gammln");
+        Kokkos::printf("bad arg in gammln");
         // exit(1);
     }
 
@@ -4541,9 +4541,9 @@ BS_REAL MNewt1d(BS_REAL guess, BS_REAL x1, BS_REAL x2, BS_REAL f0,
 
     if ((fl > zero && fh > zero) || (fl < zero && fh < zero))
     {
-        printf("xl = %.3e, fl = %.3e\n", x1, fl);
-        printf("xh = %.3e, fh = %.3e\n", x2, fh);
-        printf("Root must be bracketed in rtsafe");
+        Kokkos::printf("xl = %.3e, fl = %.3e\n", x1, fl);
+        Kokkos::printf("xh = %.3e, fh = %.3e\n", x2, fh);
+        Kokkos::printf("Root must be bracketed in rtsafe");
         exit(1);
         // throw("Root must be bracketed in rtsafe");
     }
@@ -4609,7 +4609,7 @@ BS_REAL MNewt1d(BS_REAL guess, BS_REAL x1, BS_REAL x2, BS_REAL f0,
         }
     }
     // throw("Maximum number of iterations exceeded in rtsafe");
-    printf("Maximum number of iterations exceeded in rtsafe");
+    Kokkos::printf("Maximum number of iterations exceeded in rtsafe");
     exit(1);
 }
 
@@ -4688,7 +4688,7 @@ void MNewt2d(BS_REAL* x, BS_REAL C[2],
         {
             errx += fabs(p[i]);
             x[i] += p[i];
-            // printf("x[%d] = %.3e\n", i, x[i]);
+            // Kokkos::printf("x[%d] = %.3e\n", i, x[i]);
         }
         if (errx <= tolx_2d)
             return;

--- a/include/functions.hpp
+++ b/include/functions.hpp
@@ -29,12 +29,12 @@ constexpr BS_REAL fdi_litconst          = 7.38905609893065023;
 #ifndef _USENRERRORCLASS_
 #define throw(message)                                                         \
     //} //\
-        //Kokkos::printf("ERROR: %s\n     in file %s at line %d\n", message, __FILE__, \
+        //BS_PRINTF("ERROR: %s\n     in file %s at line %d\n", message, __FILE__, \
                __LINE__);
                                                                      \
         //exit(1);
         //BS_REAL dummy_var = -42.;
-        Kokkos::printf("Throw function here");
+        BS_PRINTF("Throw function here");
                                                                       \
     //}
 #else
@@ -50,7 +50,7 @@ struct NRerror
 #define throw(message) throw(NRerror(message, __FILE__, __LINE__));
 void NRcatch(NRerror err)
 {
-    Kokkos::printf("ERROR: %s\n     in file %s at line %d\n", err.message, err.file,
+    BS_PRINTF("ERROR: %s\n     in file %s at line %d\n", err.message, err.file,
            err.line);
     exit(1);
 }
@@ -327,7 +327,7 @@ void SFPsiOutput(const BS_REAL x, SFResult* result)
     {
         // result->val = std::nan;
         // result->err = std::nan;
-        Kokkos::printf("Error in digamma computation\n");
+        BS_PRINTF("Error in digamma computation\n");
         exit(EXIT_FAILURE);
     }
     else if (y >= 2.0)
@@ -343,7 +343,7 @@ void SFPsiOutput(const BS_REAL x, SFResult* result)
             {
                 // result->val = std::nan;
                 // result->err = std::nan;
-                Kokkos::printf("Error in digamma computation\n");
+                BS_PRINTF("Error in digamma computation\n");
                 exit(EXIT_FAILURE);
             }
             else
@@ -4433,7 +4433,7 @@ BS_REAL Gammln(const BS_REAL xx)
     if (xx <= 0)
     {
         // throw("bad arg in gammln");
-        Kokkos::printf("bad arg in gammln");
+        BS_PRINTF("bad arg in gammln");
         // exit(1);
     }
 
@@ -4541,9 +4541,9 @@ BS_REAL MNewt1d(BS_REAL guess, BS_REAL x1, BS_REAL x2, BS_REAL f0,
 
     if ((fl > zero && fh > zero) || (fl < zero && fh < zero))
     {
-        Kokkos::printf("xl = %.3e, fl = %.3e\n", x1, fl);
-        Kokkos::printf("xh = %.3e, fh = %.3e\n", x2, fh);
-        Kokkos::printf("Root must be bracketed in rtsafe");
+        BS_PRINTF("xl = %.3e, fl = %.3e\n", x1, fl);
+        BS_PRINTF("xh = %.3e, fh = %.3e\n", x2, fh);
+        BS_PRINTF("Root must be bracketed in rtsafe");
         exit(1);
         // throw("Root must be bracketed in rtsafe");
     }
@@ -4609,7 +4609,7 @@ BS_REAL MNewt1d(BS_REAL guess, BS_REAL x1, BS_REAL x2, BS_REAL f0,
         }
     }
     // throw("Maximum number of iterations exceeded in rtsafe");
-    Kokkos::printf("Maximum number of iterations exceeded in rtsafe");
+    BS_PRINTF("Maximum number of iterations exceeded in rtsafe");
     exit(1);
 }
 
@@ -4688,7 +4688,7 @@ void MNewt2d(BS_REAL* x, BS_REAL C[2],
         {
             errx += fabs(p[i]);
             x[i] += p[i];
-            // Kokkos::printf("x[%d] = %.3e\n", i, x[i]);
+            // BS_PRINTF("x[%d] = %.3e\n", i, x[i]);
         }
         if (errx <= tolx_2d)
             return;

--- a/include/integration.hpp
+++ b/include/integration.hpp
@@ -514,7 +514,7 @@ GaussLegendreIntegrate1D(MyQuadrature* quad, MyFunctionMultiD* func, BS_REAL* t)
 
     int num_integrands = func->my_quadrature_integrand.n;
     BS_ASSERT(num_integrands <= num_max_integrands);
-    BS_REAL f1_x[num_max_integrands][n_max], f2_x[num_max_integrands][n_max];
+    BS_REAL f1_x[num_max_integrands][BS_N_MAX], f2_x[num_max_integrands][BS_N_MAX];
     BS_REAL var[2];
     MyQuadratureIntegrand result;
 
@@ -770,7 +770,7 @@ void GaussLegendreIntegrate2DMatrixForNEPS(const MyQuadrature* quad,
 KOKKOS_INLINE_FUNCTION
 MyQuadratureIntegrand GaussLegendreIntegrate1DMatrix(const MyQuadrature* quad,
                                                      const int num_integrands,
-                                                     const BS_REAL mat[][n_max],
+                                                     const BS_REAL mat[][BS_N_MAX],
                                                      BS_REAL* t)
 {
     const int n = quad->nx;
@@ -805,7 +805,7 @@ MyQuadratureIntegrand GaussLegendreIntegrate1DMatrix(const MyQuadrature* quad,
 KOKKOS_INLINE_FUNCTION
 void GaussLegendreIntegrate1DMatrixOnlyNumber(const MyQuadrature* quad,
                                               const int num_integrands,
-                                              const BS_REAL mat[][n_max],
+                                              const BS_REAL mat[][BS_N_MAX],
                                               BS_REAL* t,
                                               MyQuadratureIntegrand* out_n,
                                               MyQuadratureIntegrand* out_j)

--- a/include/kernel_brem.hpp
+++ b/include/kernel_brem.hpp
@@ -370,7 +370,7 @@ MyKernelOutput BremKernelsLegCoeff(BremKernelParams* kernel_params,
         s_abs = -one * s_abs; // first Legedre coefficient
         break;
     default:
-        Kokkos::printf("BremKernelsLegCoeff (kernel_brem.c): l = %d must be either 0 "
+        BS_PRINTF("BremKernelsLegCoeff (kernel_brem.c): l = %d must be either 0 "
                "or 1\n",
                l);
     }

--- a/include/kernel_brem.hpp
+++ b/include/kernel_brem.hpp
@@ -370,7 +370,7 @@ MyKernelOutput BremKernelsLegCoeff(BremKernelParams* kernel_params,
         s_abs = -one * s_abs; // first Legedre coefficient
         break;
     default:
-        printf("BremKernelsLegCoeff (kernel_brem.c): l = %d must be either 0 "
+        Kokkos::printf("BremKernelsLegCoeff (kernel_brem.c): l = %d must be either 0 "
                "or 1\n",
                l);
     }

--- a/include/kernel_pair.hpp
+++ b/include/kernel_pair.hpp
@@ -12,12 +12,6 @@
 #include "constants.hpp"
 #include "functions.hpp"
 
-#ifdef KOKKOS_FLAG
-#define func_tgamma(x) Kokkos::tgamma(x)
-#else
-#define func_tgamma(x) tgamma(x)
-#endif
-
 
 KOKKOS_INLINE_FUNCTION
 void PairPsi(const int l, const BS_REAL y, const BS_REAL z, const BS_REAL eta,

--- a/include/m1_opacities.hpp
+++ b/include/m1_opacities.hpp
@@ -39,7 +39,7 @@ constexpr BS_REAL THRESHOLD_J = 1e-25;
 KOKKOS_INLINE_FUNCTION
 void Scattering1DIntegrand(const MyQuadrature* quad,
                            GreyOpacityParams* grey_pars, const BS_REAL* t,
-                           BS_REAL out[][n_max])
+                           BS_REAL out[][BS_N_MAX])
 {
     constexpr BS_REAL four_pi = 4 * kBS_Pi;
 
@@ -92,8 +92,8 @@ void Scattering1DIntegrand(const MyQuadrature* quad,
 
 KOKKOS_INLINE_FUNCTION
 void Beta1DIntegrand(const MyQuadrature* quad, GreyOpacityParams* grey_pars,
-                     const BS_REAL* t, BS_REAL out_em[][n_max],
-                     BS_REAL out_ab[][n_max], const int stim_abs)
+                     const BS_REAL* t, BS_REAL out_em[][BS_N_MAX],
+                     BS_REAL out_ab[][BS_N_MAX], const int stim_abs)
 {
     const int n = quad->nx;
     BS_REAL nu, nu_sqr, g_nu;
@@ -734,7 +734,7 @@ M1MatrixKokkos2D ComputeDoubleIntegrand(const MyQuadrature* quad, BS_REAL t,
 {
     const int n = quad->nx;
     BS_REAL nu, nu_bar;
-    BS_REAL nu_array[n_max];
+    BS_REAL nu_array[BS_N_MAX];
     M1MatrixKokkos2D out = {0};
 
     for (int i = 0; i < n; ++i)
@@ -1079,7 +1079,7 @@ M1Opacities ComputeM1OpacitiesGenericFormalism(
     MyQuadratureIntegrand iso_integrals = {0};
     if (my_grey_opacity_params->opacity_flags.use_iso == 1)
     {
-        BS_REAL out_iso[total_num_species][n_max];
+        BS_REAL out_iso[total_num_species][BS_N_MAX];
         Scattering1DIntegrand(quad_1d, my_grey_opacity_params, s_iso, out_iso);
         iso_integrals = GaussLegendreIntegrate1DMatrix(
             quad_1d, total_num_species, out_iso, s_iso);
@@ -1092,8 +1092,8 @@ M1Opacities ComputeM1OpacitiesGenericFormalism(
 
     if (my_grey_opacity_params->opacity_flags.use_abs_em == 1)
     {
-        BS_REAL out_beta_em[total_num_species][n_max];
-        BS_REAL out_beta_ab[total_num_species][n_max];
+        BS_REAL out_beta_em[total_num_species][BS_N_MAX];
+        BS_REAL out_beta_ab[total_num_species][BS_N_MAX];
 
         Beta1DIntegrand(quad_1d, my_grey_opacity_params, s_beta, out_beta_em,
                         out_beta_ab, stim_abs);

--- a/include/weak_magnetism.hpp
+++ b/include/weak_magnetism.hpp
@@ -94,7 +94,7 @@ void NucFrmFac(const BS_REAL E, BS_REAL* cv, BS_REAL* ca, BS_REAL* F2,
     }
     else
     {
-        printf("Error: reacflag out of range in NucFrmFac\n");
+        Kokkos::printf("Error: reacflag out of range in NucFrmFac\n");
     }
 
     *cv = frm1;

--- a/include/weak_magnetism.hpp
+++ b/include/weak_magnetism.hpp
@@ -94,7 +94,7 @@ void NucFrmFac(const BS_REAL E, BS_REAL* cv, BS_REAL* ca, BS_REAL* F2,
     }
     else
     {
-        Kokkos::printf("Error: reacflag out of range in NucFrmFac\n");
+        BS_PRINTF("Error: reacflag out of range in NucFrmFac\n");
     }
 
     *cv = frm1;

--- a/utils/export_thc.py
+++ b/utils/export_thc.py
@@ -10,7 +10,19 @@ import argparse
 import subprocess
 
 # Replacement rules go here (only change this)
-replacement_rules = [("func_tgamma", "tgamma"),("Kokkos::tgamma", "tgamma"),("Kokkos::printf", "printf"),("KOKKOS_INLINE_FUNCTION","inline")]
+replacement_rules = [("BS_PRINTF", "printf"),("KOKKOS_INLINE_FUNCTION","inline")]
+
+# Text block to replace
+text_block = """#ifndef KOKKOS_INLINE_FUNCTION
+#ifdef KOKKOS_FLAG
+#include <Kokkos_Core.hpp>
+#define BS_PRINTF Kokkos::printf
+#else
+#define KOKKOS_INLINE_FUNCTION inline
+#define BS_PRINTF printf
+#endif
+#endif
+"""
 
 # Compute the diff between a file in the source and destination
 def diff_files(source_filepath, destination_filepath):
@@ -28,6 +40,12 @@ def replace_file_content(file_content, replacements):
 
     return modified_content
 
+# Remove Kokkos block from bns_nurates.hpp
+def remove_bns_nurates_text_block(file_content):
+    modified_content = file_content.replace(text_block,"")
+    
+    return modified_content
+    
 # Perform text substitions on all files in a folder
 def refactor_and_copy(source_dir, destination_dir, replacements):
     
@@ -56,7 +74,10 @@ def refactor_and_copy(source_dir, destination_dir, replacements):
 
         with open(source_filepath, 'r') as f:
             content = f.read()
-
+            
+            if(filename == "bns_nurates.hpp"):
+                content = remove_bns_nurates_text_block(content)
+                
             modified_content = replace_file_content(content, replacements)
 
             with open(destination_filepath, 'w') as out:


### PR DESCRIPTION
This PR fixes issues with printf statements on Intel based GPUs. It also bumps up the Kokkos version to 4.6.1. It also updates the export_thc.py script.

- ```BS_PRINTF``` is used instead of regular ```printf```. This becomes a ```Kokkos::printf``` when compiling with Kokkos and a regular ```printf``` otherwise.  The Kokkos version has been updated to provide better support for SYCL.
- Changes ```n_max``` (maximum number of quadrature points) to ```BS_N_MAX``` to prevent conflicts with AthenaK.
- ```export_thc.py``` has been made considerably simpler. It now performs text substitutions to the code base to replace references to Kokkos. 
- References to ```tgamma(x)```/```func_tgamma(x)``` has been removed as the code does not use it anymore. 

Compilation with and without Kokkos and on GPUs (Nvidia) has been tested with the ```MWE``` target. Using an earlier commit, compilation has been tested with SYCL on Aurora.