### PR TITLE
Separate non-thermal processes

### DIFF
--- a/include/bns_nurates.hpp
+++ b/include/bns_nurates.hpp
@@ -474,6 +474,33 @@ struct M1Opacities
 typedef struct M1Opacities M1Opacities;
 
 
+/* M1Opacities struct with separated non-thermal processes
+ *
+ * Stores the emissivity, absorption and scattering coefficients
+ * for electron neutrino (nue), electron anti-neutrino (anue) and mu/tau
+ * neutrinos (nux) as in Radice et al. (2022)
+ * Take care about the non-thermal processes, stored using different coefficients.
+ */
+struct M1OpacitiesNonThermalSeparated
+{
+    /* Number coefficients */
+    BS_REAL eta_0[total_num_species];     // number emissivity coefficient
+    BS_REAL kappa_0_a[total_num_species]; // number absorption coefficient
+
+    /* Energy coefficients */
+    BS_REAL eta_th[total_num_species];          // energy emissivity coefficient 
+                                                // for thermal processes
+    BS_REAL eta_non_th[total_num_species];      // energy emissivity coefficient 
+                                                // for non-thermal processes
+    BS_REAL kappa_a_th[total_num_species];      // energy absorption coefficient
+                                                // for thermal processes
+    BS_REAL kappa_a_non_th[total_num_species];  // energy absorption coefficient
+                                                // for thermal processes
+    BS_REAL kappa_s[total_num_species];         // scattering coefficient
+};
+typedef struct M1OpacitiesNonThermalSeparated M1OpacitiesNonThermalSeparated;
+
+
 /* M1Matrix struct
  *
  * Stores quantities related to the computation of M1 source

--- a/include/bns_nurates.hpp
+++ b/include/bns_nurates.hpp
@@ -459,6 +459,8 @@ typedef struct GreyOpacityParams GreyOpacityParams;
  * Stores the emissivity, absorption and scattering coefficients
  * for electron neutrino (nue), electron anti-neutrino (anue) and mu/tau
  * neutrinos (nux) as in Radice et al. (2022)
+ * 
+ * NEPS is included in all the quantities (excluded kappa_s).
  */
 struct M1Opacities
 {
@@ -474,12 +476,15 @@ struct M1Opacities
 typedef struct M1Opacities M1Opacities;
 
 
-/* M1Opacities struct with separated non-thermal processes
+/* M1OpacitiesNonThermalSeparated struct
  *
  * Stores the emissivity, absorption and scattering coefficients
  * for electron neutrino (nue), electron anti-neutrino (anue) and mu/tau
  * neutrinos (nux) as in Radice et al. (2022)
- * Take care about the non-thermal processes, stored using different coefficients.
+ * 
+ * NEPS is treated separately from other reactions.
+ * NEPS is not considered for computation of number emissivity (eta_0) 
+ * and absorsivity (kappa_0_a).
  */
 struct M1OpacitiesNonThermalSeparated
 {

--- a/include/m1_opacities.hpp
+++ b/include/m1_opacities.hpp
@@ -1056,6 +1056,7 @@ M1MatrixKokkos2D ComputeNEPSIntegrand(const MyQuadrature* quad, BS_REAL t,
     return out;
 }
 
+
 /* Computes the opacities for the M1 code
  *
  */
@@ -1294,6 +1295,276 @@ M1Opacities ComputeM1OpacitiesGenericFormalism(
     return m1_opacities;
 }
 
+
+/* Computes the opacities for the M1 code
+ * Separate non-thermal processes from thermal ones.
+ */
+KOKKOS_INLINE_FUNCTION
+M1OpacitiesNonThermalSeparated ComputeM1OpacitiesGenericFormalismNonThermalSeparated(
+                const MyQuadrature* quad_1d, const MyQuadrature* quad_2d,
+                GreyOpacityParams* my_grey_opacity_params, const int stim_abs)
+{
+    constexpr BS_REAL four    = 4;
+    constexpr BS_REAL c_light = kBS_Clight;
+
+    BS_REAL n[total_num_species];
+    BS_REAL J[total_num_species];
+
+    for (int idx = 0; idx < total_num_species; ++idx)
+    {
+        // m1_pars.n and m1_pars.J are assumed to be parsed in [nm^-3]
+        // and [MeV nm^-3]
+        n[idx] = my_grey_opacity_params->m1_pars.n[idx];
+        J[idx] = my_grey_opacity_params->m1_pars.J[idx];
+    }
+
+    const BS_REAL temp  = my_grey_opacity_params->eos_pars.temp;
+    const BS_REAL eta_e = my_grey_opacity_params->eos_pars.mu_e / temp;
+
+    constexpr BS_REAL three_halves  = 1.5;
+    constexpr BS_REAL five_sixths   = 0.8333333333333333;
+    constexpr BS_REAL five          = 5;
+    constexpr BS_REAL temp_multiple = 0.5 * 4.364;
+    const BS_REAL s_pair            = temp_multiple * temp;
+    // const BS_REAL s_pair              = temp * (FDI_p4(eta_e) / FDI_p3(eta_e)
+    // + FDI_p4(-eta_e) / FDI_p3(-eta_e));
+    const BS_REAL s_nux  = three_halves * temp;
+    const BS_REAL s_neps = temp_multiple * temp;
+
+    BS_REAL s_beta[total_num_species] = {0}, s_iso[total_num_species] = {0};
+
+    if (eta_e > -30. and eta_e < 30.)
+    {
+        s_beta[id_nue]  = temp * FDI_p5(eta_e) / FDI_p4(eta_e);
+        s_beta[id_anue] = temp * FDI_p5(-eta_e) / FDI_p4(-eta_e);
+    }
+    else if (eta_e > 30.)
+    {
+        s_beta[id_nue]  = temp * eta_e * five_sixths;
+        s_beta[id_anue] = temp * five;
+    }
+    else
+    {
+        s_beta[id_nue]  = temp * five;
+        s_beta[id_anue] = temp * eta_e * five_sixths;
+    }
+
+    for (int idx = 0; idx < total_num_species; ++idx)
+    {
+        s_iso[idx] = (n[idx] > THRESHOLD_N) ? (J[idx] / n[idx]) : s_nux;
+    }
+
+
+    MyQuadratureIntegrand iso_integrals = {0};
+    if (my_grey_opacity_params->opacity_flags.use_iso == 1)
+    {
+        BS_REAL out_iso[total_num_species][BS_N_MAX];
+        Scattering1DIntegrand(quad_1d, my_grey_opacity_params, s_iso, out_iso);
+        iso_integrals = GaussLegendreIntegrate1DMatrix(
+            quad_1d, total_num_species, out_iso, s_iso);
+    }
+
+    MyQuadratureIntegrand beta_n_em_integrals  = {0};
+    MyQuadratureIntegrand beta_j_em_integrals  = {0};
+    MyQuadratureIntegrand beta_n_abs_integrals = {0};
+    MyQuadratureIntegrand beta_j_abs_integrals = {0};
+
+    if (my_grey_opacity_params->opacity_flags.use_abs_em == 1)
+    {
+        BS_REAL out_beta_em[total_num_species][BS_N_MAX];
+        BS_REAL out_beta_ab[total_num_species][BS_N_MAX];
+
+        Beta1DIntegrand(quad_1d, my_grey_opacity_params, s_beta, out_beta_em,
+                        out_beta_ab, stim_abs);
+
+        GaussLegendreIntegrate1DMatrixOnlyNumber(quad_1d, 2, out_beta_em,
+                                                 s_beta, &beta_n_em_integrals,
+                                                 &beta_j_em_integrals);
+        GaussLegendreIntegrate1DMatrixOnlyNumber(quad_1d, 2, out_beta_ab,
+                                                 s_beta, &beta_n_abs_integrals,
+                                                 &beta_j_abs_integrals);
+    }
+
+
+    MyQuadratureIntegrand n_integrals_2d = {0};
+    MyQuadratureIntegrand e_integrals_2d = {0};
+
+    if ((my_grey_opacity_params->opacity_flags.use_pair == 1) ||
+        (my_grey_opacity_params->opacity_flags.use_brem == 1))
+    {
+        M1MatrixKokkos2D out_pair = ComputeDoubleIntegrand(
+            quad_2d, s_pair, my_grey_opacity_params, stim_abs);
+        GaussLegendreIntegrate2DMatrixForM1Coeffs(
+            quad_2d, &out_pair, s_pair, &n_integrals_2d, &e_integrals_2d);
+    }
+
+    MyQuadratureIntegrand n_neps_2d = {0};
+    MyQuadratureIntegrand e_neps_2d = {0};
+
+    if (my_grey_opacity_params->opacity_flags.use_inelastic_scatt == 1)
+    {
+        M1MatrixKokkos2D out_inel = ComputeNEPSIntegrand(
+            quad_2d, four * s_neps, my_grey_opacity_params, stim_abs);
+        GaussLegendreIntegrate2DMatrixForNEPS(quad_2d, &out_inel, four * s_neps,
+                                              &n_neps_2d, &e_neps_2d);
+    }
+
+    M1OpacitiesNonThermalSeparated m1_opacities_non_th_separated = {0};
+
+    /* Set all opacities to zero. They'll be left as 0 if the neutrino
+    number/energy density is too low (to avoid inf/nan, since the number/energy
+    density appears in the denominator). Note that emissivities do no need this
+    precaution (and it also make sense physically: you can produce neutrinos
+    even if there are none to start with). */
+    constexpr BS_REAL zero = 0;
+    for (int idx = 0; idx < total_num_species; ++idx)
+    {
+        m1_opacities_non_th_separated.kappa_0_a[idx]      = zero;
+        m1_opacities_non_th_separated.kappa_a_th[idx]        = zero;
+        m1_opacities_non_th_separated.kappa_a_non_th[idx] = zero;
+        m1_opacities_non_th_separated.kappa_s[idx]        = zero;
+    }
+
+    /* Electron neutrinos */
+    m1_opacities_non_th_separated.eta_0[id_nue] =
+        kBS_FourPi_hc3 * (kBS_FourPi_hc3 * n_integrals_2d.integrand[0] +
+                          beta_n_em_integrals.integrand[id_nue]);
+
+    m1_opacities_non_th_separated.eta_th[id_nue] =
+        kBS_FourPi_hc3 * (kBS_FourPi_hc3 * e_integrals_2d.integrand[0] +
+                          beta_j_em_integrals.integrand[id_nue]);
+
+    m1_opacities_non_th_separated.eta_non_th[id_nue] =
+        kBS_FourPi_hc3 * kBS_FourPi_hc3 * e_neps_2d.integrand[0];
+
+    if (n[id_nue] > THRESHOLD_N)
+    {
+        m1_opacities_non_th_separated.kappa_0_a[id_nue] =
+            kBS_FourPi_hc3 / (c_light * n[id_nue]) *
+            (kBS_FourPi_hc3 * n_integrals_2d.integrand[4] +
+             beta_n_abs_integrals.integrand[id_nue]);
+    }
+    if (J[id_nue] > THRESHOLD_J)
+    {
+        m1_opacities_non_th_separated.kappa_a_th[id_nue] =
+            n[id_nue] == zero ?
+                zero :
+                kBS_FourPi_hc3 / (c_light * J[id_nue]) *
+                    (kBS_FourPi_hc3 * e_integrals_2d.integrand[4] +
+                     beta_j_abs_integrals.integrand[id_nue]);
+
+        m1_opacities_non_th_separated.kappa_a_non_th[id_nue] =
+            n[id_nue] == zero ?
+                zero :
+                kBS_FourPi_hc3 / (c_light * J[id_nue]) *
+                    (kBS_FourPi_hc3 * e_neps_2d.integrand[4]);
+
+        m1_opacities_non_th_separated.kappa_s[id_nue] = kBS_FourPi_hc3 / (c_light * J[id_nue]) *
+                                       iso_integrals.integrand[id_nue];
+    }
+
+    /* Electron anti-neutrinos */
+    m1_opacities_non_th_separated.eta_0[id_anue] =
+        kBS_FourPi_hc3 * (kBS_FourPi_hc3 * n_integrals_2d.integrand[1] +
+                          beta_n_em_integrals.integrand[id_anue]);
+
+    m1_opacities_non_th_separated.eta_th[id_anue] =
+        kBS_FourPi_hc3 * (kBS_FourPi_hc3 * e_integrals_2d.integrand[1] +
+                          beta_j_em_integrals.integrand[id_anue]);
+
+    m1_opacities_non_th_separated.eta_non_th[id_anue] =
+        kBS_FourPi_hc3 * kBS_FourPi_hc3 * e_neps_2d.integrand[1];
+
+    if (n[id_anue] > THRESHOLD_N)
+    {
+        m1_opacities_non_th_separated.kappa_0_a[id_anue] =
+            kBS_FourPi_hc3 / (c_light * n[id_anue]) *
+            (kBS_FourPi_hc3 * n_integrals_2d.integrand[5] +
+             beta_n_abs_integrals.integrand[id_anue]);
+    }
+    if (J[id_anue] > THRESHOLD_J)
+    {
+        m1_opacities_non_th_separated.kappa_a_th[id_anue] =
+            kBS_FourPi_hc3 / (c_light * J[id_anue]) *
+            (kBS_FourPi_hc3 * e_integrals_2d.integrand[5] +
+             beta_j_abs_integrals.integrand[id_anue]);
+
+        m1_opacities_non_th_separated.kappa_a_non_th[id_anue] =
+            kBS_FourPi_hc3 / (c_light * J[id_anue]) *
+            (kBS_FourPi_hc3 * e_neps_2d.integrand[5]);
+
+        m1_opacities_non_th_separated.kappa_s[id_anue] = kBS_FourPi_hc3 /
+                                        (c_light * J[id_anue]) *
+                                        iso_integrals.integrand[id_anue];
+    }
+
+    /* Heavy neutrinos */
+    m1_opacities_non_th_separated.eta_0[id_nux] =
+        kBS_FourPi_hc3_sqr * n_integrals_2d.integrand[2];
+
+    m1_opacities_non_th_separated.eta_th[id_nux] =
+        kBS_FourPi_hc3_sqr * e_integrals_2d.integrand[2];
+
+    m1_opacities_non_th_separated.eta_non_th[id_nux] =
+        kBS_FourPi_hc3_sqr * e_neps_2d.integrand[2];
+
+    if (n[id_nux] > THRESHOLD_N)
+    {
+        m1_opacities_non_th_separated.kappa_0_a[id_nux] =
+            kBS_FourPi_hc3_sqr / (c_light * n[id_nux]) *
+            n_integrals_2d.integrand[6];
+    }
+    if (J[id_nux] > THRESHOLD_J)
+    {
+        m1_opacities_non_th_separated.kappa_a_th[id_nux] =
+            kBS_FourPi_hc3_sqr / (c_light * J[id_nux]) *
+            e_integrals_2d.integrand[6];
+
+        m1_opacities_non_th_separated.kappa_a_non_th[id_nux] =
+            kBS_FourPi_hc3_sqr / (c_light * J[id_nux]) *
+            e_neps_2d.integrand[6];
+
+        m1_opacities_non_th_separated.kappa_s[id_nux] = kBS_FourPi_hc3 / (c_light * J[id_nux]) *
+                                       iso_integrals.integrand[id_nux];
+    }
+
+    /* Heavy anti-neutrinos */
+    m1_opacities_non_th_separated.eta_0[id_anux] =
+        kBS_FourPi_hc3_sqr * n_integrals_2d.integrand[3];
+
+    m1_opacities_non_th_separated.eta_th[id_anux] =
+        kBS_FourPi_hc3_sqr * e_integrals_2d.integrand[3];
+
+    m1_opacities_non_th_separated.eta_non_th[id_anux] =
+        kBS_FourPi_hc3_sqr * e_neps_2d.integrand[3];
+
+    if (n[id_anux] > THRESHOLD_N)
+    {
+        m1_opacities_non_th_separated.kappa_0_a[id_anux] =
+            n[id_anux] == zero ?
+                zero :
+                kBS_FourPi_hc3_sqr / (c_light * n[id_anux]) *
+                    n_integrals_2d.integrand[7];
+    }
+    if (J[id_anux] > THRESHOLD_J)
+    {
+        m1_opacities_non_th_separated.kappa_a_th[id_anux] =
+            kBS_FourPi_hc3_sqr / (c_light * J[id_anux]) *
+            e_integrals_2d.integrand[7];
+
+        m1_opacities_non_th_separated.kappa_a_non_th[id_anux] =
+            kBS_FourPi_hc3_sqr / (c_light * J[id_anux]) *
+            e_neps_2d.integrand[7];
+
+        m1_opacities_non_th_separated.kappa_s[id_anux] = kBS_FourPi_hc3 /
+                                        (c_light * J[id_anux]) *
+                                        iso_integrals.integrand[id_anux];
+    }
+
+    return m1_opacities_non_th_separated;
+}
+
+
 KOKKOS_INLINE_FUNCTION
 M1Opacities
 ComputeM1OpacitiesNotStimulated(MyQuadrature* quad_1d, MyQuadrature* quad_2d,
@@ -1303,6 +1574,7 @@ ComputeM1OpacitiesNotStimulated(MyQuadrature* quad_1d, MyQuadrature* quad_2d,
                                               my_grey_opacity_params, 0);
 }
 
+
 KOKKOS_INLINE_FUNCTION
 M1Opacities ComputeM1Opacities(const MyQuadrature* quad_1d,
                                const MyQuadrature* quad_2d,
@@ -1311,6 +1583,29 @@ M1Opacities ComputeM1Opacities(const MyQuadrature* quad_1d,
     return ComputeM1OpacitiesGenericFormalism(quad_1d, quad_2d,
                                               my_grey_opacity_params, 1);
 }
+
+
+KOKKOS_INLINE_FUNCTION
+M1OpacitiesNonThermalSeparated
+ComputeM1OpacitiesNotStimulatedNonThermalSeparated(
+                    MyQuadrature* quad_1d, MyQuadrature* quad_2d,
+                    GreyOpacityParams* my_grey_opacity_params)
+{
+    return ComputeM1OpacitiesGenericFormalismNonThermalSeparated(
+                        quad_1d, quad_2d, my_grey_opacity_params, 0);
+}
+
+
+KOKKOS_INLINE_FUNCTION
+M1OpacitiesNonThermalSeparated 
+ComputeM1OpacitiesNonThermalSeparated(
+            const MyQuadrature* quad_1d, const MyQuadrature* quad_2d, 
+            GreyOpacityParams* my_grey_opacity_params)
+{
+    return ComputeM1OpacitiesGenericFormalismNonThermalSeparated(
+                                quad_1d, quad_2d, my_grey_opacity_params, 1);
+}
+
 
 /* Compute the integrands for the computation of the spectral emissivity and
  * inverse mean free path */

--- a/include/m1_opacities.hpp
+++ b/include/m1_opacities.hpp
@@ -1057,8 +1057,12 @@ M1MatrixKokkos2D ComputeNEPSIntegrand(const MyQuadrature* quad, BS_REAL t,
 }
 
 
-/* Computes the opacities for the M1 code
+/* Computes the opacities for the M1 code, with thermal and
+ * non-thermal processes treated together.
  *
+ * NEPS is treated together with other reactions.
+ * NEPS is considered for computation of number emissivity (eta_0) 
+ * and absorsivity (kappa_0_a).
  */
 KOKKOS_INLINE_FUNCTION
 M1Opacities ComputeM1OpacitiesGenericFormalism(
@@ -1296,8 +1300,12 @@ M1Opacities ComputeM1OpacitiesGenericFormalism(
 }
 
 
-/* Computes the opacities for the M1 code
- * Separate non-thermal processes from thermal ones.
+/* Computes the opacities for the M1 code, with thermal and
+ * non-thermal processes treated separately.
+ *
+ * NEPS is treated separately from other reactions.
+ * NEPS is NOT considered for computation of number emissivity (eta_0) 
+ * and absorsivity (kappa_0_a).
  */
 KOKKOS_INLINE_FUNCTION
 M1OpacitiesNonThermalSeparated ComputeM1OpacitiesGenericFormalismNonThermalSeparated(
@@ -1420,7 +1428,7 @@ M1OpacitiesNonThermalSeparated ComputeM1OpacitiesGenericFormalismNonThermalSepar
     for (int idx = 0; idx < total_num_species; ++idx)
     {
         m1_opacities_non_th_separated.kappa_0_a[idx]      = zero;
-        m1_opacities_non_th_separated.kappa_a_th[idx]        = zero;
+        m1_opacities_non_th_separated.kappa_a_th[idx]     = zero;
         m1_opacities_non_th_separated.kappa_a_non_th[idx] = zero;
         m1_opacities_non_th_separated.kappa_s[idx]        = zero;
     }

--- a/mwe.cpp
+++ b/mwe.cpp
@@ -70,6 +70,7 @@ int main(int argc, char* argv[])
     // computation of spectral and gray rates, respectively
     SpectralOpacities spectral_rates;
     M1Opacities gray_rates;
+    M1OpacitiesNonThermalSeparated gray_rates_non_th_separated;
 
     // Create an opacity params structure, to activate/deactivate specific
     // reactions or corrections and pass physical parameters
@@ -256,11 +257,12 @@ int main(int argc, char* argv[])
 
     // Compute and output gray emissivities and opacities (Eqs. (19)-(23) in
     // Chiesa+25 PRD)
+    // THERMAL and NON-THERMAL ALL TOGETHER
     gray_rates = ComputeM1Opacities(&my_quadrature, &my_quadrature,
                                     &my_grey_opacity_params);
 
     // The numerical factors restore usual units (see output)
-    printf("Gray rates assuming equilibrium\n");
+    printf("Gray rates assuming equilibrium ALL TOGETHER\n");
     printf("------------------------------\n");
     printf(
         "     eta0          eta1          kappa0        kappa1        scat1\n");
@@ -282,6 +284,51 @@ int main(int argc, char* argv[])
            gray_rates.kappa_0_a[id_anux] * 1e7,
            gray_rates.kappa_a[id_anux] * 1e7,
            gray_rates.kappa_s[id_anux] * 1e7);
+
+    // Compute and output gray emissivities and opacities (Eqs. (19)-(23) in
+    // Chiesa+25 PRD)
+    // THERMAL and NON-THERMAL SEPARATED
+    gray_rates_non_th_separated = ComputeM1OpacitiesNonThermalSeparated(&my_quadrature, &my_quadrature,
+                                    &my_grey_opacity_params);
+
+    // The numerical factors restore usual units (see output)
+    printf("Gray rates assuming equilibrium NON-THERMAL SEPARATED\n");
+    printf("------------------------------\n");
+    printf(
+        "     eta0          eta1_th      eta1_non_th    kappa0          kappa1_th        kappa1_non_th        scat1\n");
+    printf(" nue %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e\n",
+           gray_rates_non_th_separated.eta_0[id_nue] * 1e21, 
+           gray_rates_non_th_separated.eta_th[id_nue] * 1e21,
+           gray_rates_non_th_separated.eta_non_th[id_nue] * 1e21,
+           gray_rates_non_th_separated.kappa_0_a[id_nue] * 1e7, 
+           gray_rates_non_th_separated.kappa_a_th[id_nue] * 1e7,
+           gray_rates_non_th_separated.kappa_a_non_th[id_nue] * 1e7,
+           gray_rates_non_th_separated.kappa_s[id_nue] * 1e7);
+    printf("anue %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e\n",
+           gray_rates_non_th_separated.eta_0[id_anue] * 1e21, 
+           gray_rates_non_th_separated.eta_th[id_anue] * 1e21,
+           gray_rates_non_th_separated.eta_non_th[id_anue] * 1e21,
+           gray_rates_non_th_separated.kappa_0_a[id_anue] * 1e7,
+           gray_rates_non_th_separated.kappa_a_th[id_anue] * 1e7,
+           gray_rates_non_th_separated.kappa_a_non_th[id_anue] * 1e7,
+           gray_rates_non_th_separated.kappa_s[id_anue] * 1e7);
+    printf(" nux %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e\n",
+           gray_rates_non_th_separated.eta_0[id_nux] * 1e21, 
+           gray_rates_non_th_separated.eta_th[id_nux] * 1e21,
+           gray_rates_non_th_separated.eta_non_th[id_nux] * 1e21,
+           gray_rates_non_th_separated.kappa_0_a[id_nux] * 1e7, 
+           gray_rates_non_th_separated.kappa_a_th[id_nux] * 1e7,
+           gray_rates_non_th_separated.kappa_a_non_th[id_nux] * 1e7,
+           gray_rates_non_th_separated.kappa_s[id_nux] * 1e7);
+    printf("anux %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e\n\n",
+           gray_rates_non_th_separated.eta_0[id_anux] * 1e21, 
+           gray_rates_non_th_separated.eta_th[id_anux] * 1e21,
+           gray_rates_non_th_separated.eta_non_th[id_anux] * 1e21,
+           gray_rates_non_th_separated.kappa_0_a[id_anux] * 1e7,
+           gray_rates_non_th_separated.kappa_a_th[id_anux] * 1e7,
+           gray_rates_non_th_separated.kappa_a_non_th[id_anux] * 1e7,
+           gray_rates_non_th_separated.kappa_s[id_anux] * 1e7);
+
 
     ////////////////////////////////////////////////////////////////////
     // PART 2: compute rates reconstructing the neutrino distribution //

--- a/mwe.cpp
+++ b/mwe.cpp
@@ -101,7 +101,7 @@ int main(int argc, char* argv[])
     my_grey_opacity_params.opacity_pars.use_WM_sc =
         1; // Activate isoenergetic scattering weak magnetism correction
     my_grey_opacity_params.opacity_pars.brem_implementation =
-        "GP19"; // Select bremsstrahlung implementation: Guo and Pinedo 2019
+        BREM_GP19; // Select bremsstrahlung implementation: Guo and Pinedo 2019
     my_grey_opacity_params.opacity_pars.use_NN_medium_corr =
         1; // Activate NN bremsstrahlung medium correction as in Fischer+16
 

--- a/mwe.cpp
+++ b/mwe.cpp
@@ -228,6 +228,7 @@ int main(int argc, char* argv[])
            my_grey_opacity_params.m1_pars.chi[id_nux],
            my_grey_opacity_params.m1_pars.chi[id_anux]);
 
+
     // Compute and output spectral emissivities and inverse mean free paths (not
     // in the stimulated absorption formalism)
     spectral_rates = ComputeSpectralOpacitiesNotStimulatedAbs(
@@ -255,14 +256,17 @@ int main(int argc, char* argv[])
            spectral_rates.kappa[id_anux] * 1e7,
            spectral_rates.kappa_s[id_anux] * 1e7);
 
+
     // Compute and output gray emissivities and opacities (Eqs. (19)-(23) in
     // Chiesa+25 PRD)
-    // THERMAL and NON-THERMAL ALL TOGETHER
+    // Thermal and non-thermal processes are all together.
+    // NEPS is included in the total emissivities/absorsivities.
+    // NEPS contribution is included in number quantities (eta0 and kappa0).
     gray_rates = ComputeM1Opacities(&my_quadrature, &my_quadrature,
                                     &my_grey_opacity_params);
 
     // The numerical factors restore usual units (see output)
-    printf("Gray rates assuming equilibrium, NEPS INCLUDED\n");
+    printf("Gray rates assuming equilibrium, NEPS INCLUDED (also in eta0 and kappa0)\n");
     printf("------------------------------\n");
     printf(
         "     eta0          eta1          kappa0        kappa1        scat1\n");
@@ -285,14 +289,18 @@ int main(int argc, char* argv[])
            gray_rates.kappa_a[id_anux] * 1e7,
            gray_rates.kappa_s[id_anux] * 1e7);
 
+
     // Compute and output gray emissivities and opacities (Eqs. (19)-(23) in
     // Chiesa+25 PRD)
-    // THERMAL and NON-THERMAL SEPARATED
+    // Thermal and non-thermal processes are separated.
+    // NEPS emissivity and absorsivity are separated from ones related to 
+    // other processes.
+    // NEPS contribution is NOT included in number quantities (eta0 and kappa0).
     gray_rates_non_th_separated = ComputeM1OpacitiesNonThermalSeparated(
                         &my_quadrature, &my_quadrature, &my_grey_opacity_params);
 
     // The numerical factors restore usual units (see output)
-    printf("Gray rates assuming equilibrium, NEPS SEPARATED\n");
+    printf("Gray rates assuming equilibrium, NEPS SEPARATED, NEPS NOT INCLUDED in eta0 and kappa0\n");
     printf("------------------------------\n");
     printf(
         "     eta0          eta1_th       eta1_non_th   kappa0        kappa1_th     kappa1_non_th scat1\n");
@@ -380,11 +388,14 @@ int main(int argc, char* argv[])
 
     // Compute and output gray emissivities and opacities (Eqs. (19)-(23) in
     // Chiesa+25 PRD)
+    // Thermal and non-thermal processes are all together.
+    // NEPS is included in the total emissivities/absorsivities.
+    // NEPS contribution is included in number quantities (eta0 and kappa0).
     gray_rates = ComputeM1Opacities(&my_quadrature, &my_quadrature,
                                     &my_grey_opacity_params);
 
     // The numerical factors restore usual units (see output)
-    printf("Gray rates reconstructing distribution function, NEPS INCLUDED\n");
+    printf("Gray rates reconstructing distribution function, NEPS INCLUDED (also in eta0 and kappa0)\n");
     printf("----------------------------------------------\n");
     printf(
         "     eta0          eta1          kappa0        kappa1        scat1\n");
@@ -409,12 +420,16 @@ int main(int argc, char* argv[])
 
 
     // Compute and output gray emissivities and opacities (Eqs. (19)-(23) in
-    // Chiesa+25 PRD) 
+    // Chiesa+25 PRD)
+    // Thermal and non-thermal processes are separated.
+    // NEPS emissivity and absorsivity are separated from ones related to 
+    // other processes.
+    // NEPS contribution is NOT included in number quantities (eta0 and kappa0).
     gray_rates_non_th_separated = ComputeM1OpacitiesNonThermalSeparated(
                             &my_quadrature, &my_quadrature, &my_grey_opacity_params);
 
     // The numerical factors restore usual units (see output)
-    printf("Gray rates reconstructing distribution function, NEPS SEPARATED\n");
+    printf("Gray rates reconstructing distribution function, NEPS SEPARATED, NEPS NOT INCLUDED in eta0 and kappa0\n");
     printf("------------------------------\n");
     printf(
         "     eta0          eta1_th       eta1_non_th   kappa0        kappa1_th     kappa1_non_th scat1\n");
@@ -456,9 +471,9 @@ int main(int argc, char* argv[])
            "Spectral emissivity 'j'/'j_s'                 :           s^-1\n"
            "Spectral imfp 'kappa'/'kappa_s'               :          cm^-1\n"
            "Gray number emissivity 'eta0'                 :     cm^-3 s^-1\n"
-           "Gray energy emissivity 'eta1'(th and non-th) : MeV cm^-3 s^-1\n"
+           "Gray energy emissivity 'eta1'(th and non-th)  : MeV cm^-3 s^-1\n"
            "Gray number opacity 'kappa0'                  :          cm^-1\n"
-           "Gray energy opacity 'kappa1'(th and non-th)  :          cm^-1\n"
+           "Gray energy opacity 'kappa1'(th and non-th)   :          cm^-1\n"
            "Gray scattering opacity 'scat1'               :          cm^-1\n");
 
     return 0;

--- a/mwe.cpp
+++ b/mwe.cpp
@@ -262,7 +262,7 @@ int main(int argc, char* argv[])
                                     &my_grey_opacity_params);
 
     // The numerical factors restore usual units (see output)
-    printf("Gray rates assuming equilibrium ALL TOGETHER\n");
+    printf("Gray rates assuming equilibrium, NEPS INCLUDED\n");
     printf("------------------------------\n");
     printf(
         "     eta0          eta1          kappa0        kappa1        scat1\n");
@@ -288,14 +288,14 @@ int main(int argc, char* argv[])
     // Compute and output gray emissivities and opacities (Eqs. (19)-(23) in
     // Chiesa+25 PRD)
     // THERMAL and NON-THERMAL SEPARATED
-    gray_rates_non_th_separated = ComputeM1OpacitiesNonThermalSeparated(&my_quadrature, &my_quadrature,
-                                    &my_grey_opacity_params);
+    gray_rates_non_th_separated = ComputeM1OpacitiesNonThermalSeparated(
+                        &my_quadrature, &my_quadrature, &my_grey_opacity_params);
 
     // The numerical factors restore usual units (see output)
-    printf("Gray rates assuming equilibrium NON-THERMAL SEPARATED\n");
+    printf("Gray rates assuming equilibrium, NEPS SEPARATED\n");
     printf("------------------------------\n");
     printf(
-        "     eta0          eta1_th      eta1_non_th    kappa0          kappa1_th        kappa1_non_th        scat1\n");
+        "     eta0          eta1_th       eta1_non_th   kappa0        kappa1_th     kappa1_non_th scat1\n");
     printf(" nue %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e\n",
            gray_rates_non_th_separated.eta_0[id_nue] * 1e21, 
            gray_rates_non_th_separated.eta_th[id_nue] * 1e21,
@@ -377,13 +377,14 @@ int main(int argc, char* argv[])
            spectral_rates.kappa[id_anux] * 1e7,
            spectral_rates.kappa_s[id_anux] * 1e7);
 
+
     // Compute and output gray emissivities and opacities (Eqs. (19)-(23) in
     // Chiesa+25 PRD)
     gray_rates = ComputeM1Opacities(&my_quadrature, &my_quadrature,
                                     &my_grey_opacity_params);
 
     // The numerical factors restore usual units (see output)
-    printf("Gray rates reconstructing distribution function\n");
+    printf("Gray rates reconstructing distribution function, NEPS INCLUDED\n");
     printf("----------------------------------------------\n");
     printf(
         "     eta0          eta1          kappa0        kappa1        scat1\n");
@@ -406,15 +407,59 @@ int main(int argc, char* argv[])
            gray_rates.kappa_a[id_anux] * 1e7,
            gray_rates.kappa_s[id_anux] * 1e7);
 
+
+    // Compute and output gray emissivities and opacities (Eqs. (19)-(23) in
+    // Chiesa+25 PRD) 
+    gray_rates_non_th_separated = ComputeM1OpacitiesNonThermalSeparated(
+                            &my_quadrature, &my_quadrature, &my_grey_opacity_params);
+
+    // The numerical factors restore usual units (see output)
+    printf("Gray rates reconstructing distribution function, NEPS SEPARATED\n");
+    printf("------------------------------\n");
+    printf(
+        "     eta0          eta1_th       eta1_non_th   kappa0        kappa1_th     kappa1_non_th scat1\n");
+    printf(" nue %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e\n",
+           gray_rates_non_th_separated.eta_0[id_nue] * 1e21, 
+           gray_rates_non_th_separated.eta_th[id_nue] * 1e21,
+           gray_rates_non_th_separated.eta_non_th[id_nue] * 1e21,
+           gray_rates_non_th_separated.kappa_0_a[id_nue] * 1e7, 
+           gray_rates_non_th_separated.kappa_a_th[id_nue] * 1e7,
+           gray_rates_non_th_separated.kappa_a_non_th[id_nue] * 1e7,
+           gray_rates_non_th_separated.kappa_s[id_nue] * 1e7);
+    printf("anue %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e\n",
+           gray_rates_non_th_separated.eta_0[id_anue] * 1e21, 
+           gray_rates_non_th_separated.eta_th[id_anue] * 1e21,
+           gray_rates_non_th_separated.eta_non_th[id_anue] * 1e21,
+           gray_rates_non_th_separated.kappa_0_a[id_anue] * 1e7,
+           gray_rates_non_th_separated.kappa_a_th[id_anue] * 1e7,
+           gray_rates_non_th_separated.kappa_a_non_th[id_anue] * 1e7,
+           gray_rates_non_th_separated.kappa_s[id_anue] * 1e7);
+    printf(" nux %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e\n",
+           gray_rates_non_th_separated.eta_0[id_nux] * 1e21, 
+           gray_rates_non_th_separated.eta_th[id_nux] * 1e21,
+           gray_rates_non_th_separated.eta_non_th[id_nux] * 1e21,
+           gray_rates_non_th_separated.kappa_0_a[id_nux] * 1e7, 
+           gray_rates_non_th_separated.kappa_a_th[id_nux] * 1e7,
+           gray_rates_non_th_separated.kappa_a_non_th[id_nux] * 1e7,
+           gray_rates_non_th_separated.kappa_s[id_nux] * 1e7);
+    printf("anux %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e %-13.6e\n\n",
+           gray_rates_non_th_separated.eta_0[id_anux] * 1e21, 
+           gray_rates_non_th_separated.eta_th[id_anux] * 1e21,
+           gray_rates_non_th_separated.eta_non_th[id_anux] * 1e21,
+           gray_rates_non_th_separated.kappa_0_a[id_anux] * 1e7,
+           gray_rates_non_th_separated.kappa_a_th[id_anux] * 1e7,
+           gray_rates_non_th_separated.kappa_a_non_th[id_anux] * 1e7,
+           gray_rates_non_th_separated.kappa_s[id_anux] * 1e7);
+
     printf("Units\n"
            "-----\n"
-           "Spectral emissivity 'j'/'j_s'   :           s^-1\n"
-           "Spectral imfp 'kappa'/'kappa_s' :          cm^-1\n"
-           "Gray number emissivity 'eta0'   :     cm^-3 s^-1\n"
-           "Gray energy emissivity 'eta1'   : MeV cm^-3 s^-1\n"
-           "Gray number opacity 'kappa0'    :          cm^-1\n"
-           "Gray energy opacity 'kappa1'    :          cm^-1\n"
-           "Gray scattering opacity 'scat1' :          cm^-1\n");
+           "Spectral emissivity 'j'/'j_s'                 :           s^-1\n"
+           "Spectral imfp 'kappa'/'kappa_s'               :          cm^-1\n"
+           "Gray number emissivity 'eta0'                 :     cm^-3 s^-1\n"
+           "Gray energy emissivity 'eta1'(th and non-th) : MeV cm^-3 s^-1\n"
+           "Gray number opacity 'kappa0'                  :          cm^-1\n"
+           "Gray energy opacity 'kappa1'(th and non-th)  :          cm^-1\n"
+           "Gray scattering opacity 'scat1'               :          cm^-1\n");
 
     return 0;
 }


### PR DESCRIPTION
The possibility to separate non-thermal absorsivities/emissivities from thermal ones is added through a new function. NEPS is treated as follows:
1. NEPS energy absorsivity and emissivity are computed and saved separately from quantities related to other processes.
2. NEPS number absorsivity and emissivity are no more computed and not included in the total eta_0 and kappa_0.